### PR TITLE
Fix `HP_Body_GetWorldTransformBuffer` typo

### DIFF
--- a/packages/havok/HavokPhysics.d.ts
+++ b/packages/havok/HavokPhysics.d.ts
@@ -434,7 +434,7 @@ export interface HavokPhysicsWithBindings extends EmscriptenModule {
     /** Releases a world handle, freeing any memory used. */
     HP_World_Release(world : HP_WorldId): Result;
     /** Returns the address of the world's body buffer, for use with
-     * HP_Body_GetWorldTransformBuffer. This result can be invalidated if a
+     * HP_Body_GetWorldTransformOffset. This result can be invalidated if a
      * body is added to the world.
      */
     HP_World_GetBodyBuffer(world: HP_WorldId): [Result, number];


### PR DESCRIPTION
The description of the `HP_World_GetBodyBuffer` method mentions `HP_Body_GetWorldTransformBuffer`, which doesn't seem to exist. I believe it was meant to be `HP_Body_GetWorldTransformOffset`.