### PR TITLE
Change materialId to material

### DIFF
--- a/packages/havok/HavokPhysics.d.ts
+++ b/packages/havok/HavokPhysics.d.ts
@@ -261,7 +261,7 @@ export interface HavokPhysicsWithBindings extends EmscriptenModule {
     /** Get the collision filter info for a shape. */
     HP_Shape_GetFilterInfo(shapeId : HP_ShapeId): [Result, FilterInfo];
     /** Sets the material of the shape to the provided material. */
-    HP_Shape_SetMaterial(shapeId : HP_ShapeId, materialId : PhysicsMaterial): Result;
+    HP_Shape_SetMaterial(shapeId : HP_ShapeId, material : PhysicsMaterial): Result;
     /** Get the material associated with the shape. */
     HP_Shape_GetMaterial(shapeId : HP_ShapeId): [Result, PhysicsMaterial];
     /** Set the density of the shape. Used when calling `HP_Shape_BuildMassProperties()`. */


### PR DESCRIPTION
Parts of the API return identifiers to an object and HP_Shape_SetMaterial takes such an identifier but only for the first parameter, HP_ShapeId. The second parameter takes the actual array of values for a material, not a materialId. This change updates the parameter name to reflect this.